### PR TITLE
Fix install of golang and helm to use yum repos

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -11,15 +11,18 @@ RUN yum-config-manager --enable ol7_addons
 RUN yum update -y && \
     yum install -y bash git gcc docker-cli vim less file curl wget ca-certificates
 
+RUN yum install -y oracle-golang-release-el7 && \
+    yum-config-manager --enable ol7_developer_golang116 && \
+    yum install -y golang-1.16
+
+RUN yum install -y oracle-olcne-release-el7 helm-3.3.4
+
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-
-RUN wget --no-verbose -O - https://storage.googleapis.com/golang/go1.14.7.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
 
 RUN if [ "${ARCH}" = "amd64" ]; then \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0; \
     fi
-RUN curl -sL https://get.helm.sh/helm-v3.3.0-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS
 ENV DAPPER_SOURCE /go/src/github.com/rancher/rancher-operator/


### PR DESCRIPTION
We are required to install all packages from the Oracle repositories so this PR replaces the installations of golang and helm so we install using yum.